### PR TITLE
Create LROSE redirect

### DIFF
--- a/LROSE
+++ b/LROSE
@@ -1,0 +1,2 @@
+<!doctype html>
+<meta http-equiv="refresh" content="0; URL='https://nsf-lrose.github.io'" />


### PR DESCRIPTION
Redirect nfs-lrose.github.io/LROSE to nfs-lrose.github.io to account for the extra LROSE path element printed on the brochure.